### PR TITLE
FM-3486 FEAT Add disabled-flag to User update in Firebase Admin SDK

### DIFF
--- a/lib/firebase/admin/auth/client.rb
+++ b/lib/firebase/admin/auth/client.rb
@@ -58,14 +58,16 @@ module Firebase
         #
         # @param [String, nil] uid The id of the user to update.
         # @param [String, nil] email The user’s primary email.
+        # @param [Boolean, nil] disabled A boolean indicating whether or not the user account is disabled.
         #
         # @raise [UpdateUserError] if a user cannot be updated.
         #
         # @return [UserRecord]
-        def update_user(uid, email: nil)
+        def update_user(uid, email: nil, disabled: nil)
           @user_manager.update_user(
             uid,
             email: email,
+            disabled: disabled
           )
         end
 

--- a/lib/firebase/admin/auth/user_manager.rb
+++ b/lib/firebase/admin/auth/user_manager.rb
@@ -54,10 +54,11 @@ module Firebase
         #
         # Update the user
         #
-        def update_user(uid, email: nil)
+        def update_user(uid, email: nil, disabled: nil)
           payload = {
             localId: validate_uid(uid),
             email: validate_email(email),
+            disabled: to_boolean(disabled)
           }.compact
           res = @client.post(with_path("accounts:update"), payload).body
           uid = res&.fetch("localId")


### PR DESCRIPTION
This repo is a fork of https://github.com/vstage/firebase-admin-sdk-ruby. https://github.com/vstage/firebase-admin-sdk-ruby already contained updating disabled-flag status in UserManager after the fork https://github.com/vstage/firebase-admin-sdk-ruby/blob/main/lib/firebase/admin/auth/user_manager.rb#L66, but was reduced in https://github.com/vstage/firebase-admin-sdk-ruby/commit/b58b434164def3fb2aacc179e6650fe3e0697f9f after exposing the update-functionality on the client-side interface. This re-adds the disabled-parameter back to the update-method in UserManager and add it on the client-side interface.