### PR TITLE
FM-3486 FIX Use correct key-name for changing FB-User-disabled flag

### DIFF
--- a/lib/firebase/admin/auth/user_manager.rb
+++ b/lib/firebase/admin/auth/user_manager.rb
@@ -58,7 +58,7 @@ module Firebase
           payload = {
             localId: validate_uid(uid),
             email: validate_email(email),
-            disabled: to_boolean(disabled)
+            disableUser: to_boolean(disabled)
           }.compact
           res = @client.post(with_path("accounts:update"), payload).body
           uid = res&.fetch("localId")


### PR DESCRIPTION
According to https://cloud.google.com/identity-platform/docs/reference/rest/v1/projects.accounts/update the key-name is `disableUser` when updating the FB-user account.